### PR TITLE
chore: Remove `lint` targets, add `format`.

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,10 @@
+README.md
+LICENSE.md
+coverage/
+node_modules/
+dist/
+pnpm-lock.yaml
+.github/
+.direnv/
+flake.lock
+result*

--- a/api/github/webhooks/index.js
+++ b/api/github/webhooks/index.js
@@ -1,8 +1,8 @@
-const { createNodeMiddleware, createProbot } = require('probot')
+const { createNodeMiddleware, createProbot } = require("probot");
 
-const app = require('../../../')
+const app = require("../../../");
 
 module.exports = createNodeMiddleware(app, {
   probot: createProbot(),
-  webhooksPath: '/api/github/webhooks'
-})
+  webhooksPath: "/api/github/webhooks",
+});

--- a/flake.nix
+++ b/flake.nix
@@ -65,12 +65,6 @@
                   files = "^.github/workflows/";
                 };
               };
-
-              excludes = [
-                "LICENSE.md"
-                "README.md"
-                "pnpm-lock.yaml"
-              ];
             };
           };
 

--- a/package.json
+++ b/package.json
@@ -10,9 +10,7 @@
     "start": "probot run ./index.js",
     "test": "jest --coverage",
     "update-snapshots": "jest --updateSnapshot",
-    "posttest": "pnpm run lint",
-    "lint": "prettier --check '{lib,test,docs}/**/*.{js,json,md}' index.js *.md package.json app.yml",
-    "lint:fix": "prettier --write '{lib,test,docs}/**/*.{js,json,md}' index.js *.md package.json app.yml"
+    "format": "prettier --write ."
   },
   "engines": {
     "node": ">=18",


### PR DESCRIPTION
We'll use `eslint` for linting in a subsequent commit.